### PR TITLE
Add Docker development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,50 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.egg-info
+.eggs
+dist
+build
+*.egg
+
+# Virtual environments
+venv
+.venv
+env
+.env
+
+# IDE
+.idea
+.vscode
+*.swp
+*.swo
+
+# Cache
+.pytest_cache
+.mypy_cache
+.coverage
+htmlcov
+
+# Data (large files)
+data/cache/*.csv
+data/cache/*.parquet
+*.h5
+*.hdf5
+
+# Logs
+*.log
+logs/
+
+# Docker
+Dockerfile*
+docker-compose*.yml
+.dockerignore
+
+# Docs
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# Fractal Trader Development Environment
+# Compatible with Docker Desktop 4.15+ / Engine 20.10+
+
+FROM python:3.11-slim-bookworm
+
+LABEL maintainer="FractalTrader"
+LABEL description="SMC Algorithmic Trading Development Environment"
+
+# Prevent interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System dependencies (minimal for vectorbt)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Create non-root user (optional, for security)
+# RUN useradd -m -s /bin/bash trader
+# USER trader
+
+WORKDIR /app
+
+# Install Python dependencies in layers (better caching)
+# Layer 1: Core scientific stack (rarely changes)
+RUN pip install --no-cache-dir \
+    numpy>=1.24.0 \
+    pandas>=2.0.0 \
+    scipy>=1.11.0
+
+# Layer 2: vectorbt (heavy, cache separately)
+RUN pip install --no-cache-dir vectorbt>=0.26.0
+
+# Layer 3: Trading & development tools
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy project (done last for better cache)
+COPY . .
+
+# Install project in editable mode
+RUN pip install -e .
+
+# Verify installation
+RUN python -c "import vectorbt; print(f'vectorbt {vectorbt.__version__}')" && \
+    python -c "from core.market_structure import find_swing_points; print('Core modules OK')"
+
+# Default command
+CMD ["bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+# Fractal Trader Development Stack
+# Tested on Docker Desktop 4.15+ (macOS Catalina compatible)
+
+version: "3.8"
+
+services:
+  # Main development environment
+  fractal-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: fractal-trader-dev
+    volumes:
+      - .:/app
+      - fractal-cache:/root/.cache
+    ports:
+      - "8888:8888"  # Jupyter (optional)
+      - "8080:8080"  # Freqtrade API (future)
+    environment:
+      - PYTHONUNBUFFERED=1
+      - PYTHONDONTWRITEBYTECODE=1
+    stdin_open: true
+    tty: true
+    command: bash
+
+  # Lightweight test runner (for CI/quick tests)
+  test-runner:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: fractal-test
+    volumes:
+      - .:/app:ro  # Read-only for safety
+    command: python -m pytest tests/ -v --tb=short
+    profiles:
+      - test  # Only runs with: docker compose --profile test up
+
+volumes:
+  fractal-cache:
+    name: fractal-trader-cache

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Fractal Trader - Docker Quick Start
+# Usage: ./docker-start.sh [command]
+#   ./docker-start.sh          - Start interactive shell
+#   ./docker-start.sh test     - Run all tests
+#   ./docker-start.sh backtest - Run example backtest
+
+set -e
+
+IMAGE_NAME="fractal-trader"
+CONTAINER_NAME="fractal-dev"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}🚀 Fractal Trader Docker Environment${NC}"
+
+# Build if needed
+if [[ "$(docker images -q $IMAGE_NAME 2> /dev/null)" == "" ]]; then
+    echo -e "${YELLOW}Building image (first time, ~5 min)...${NC}"
+    docker build -t $IMAGE_NAME .
+fi
+
+case "${1:-shell}" in
+    shell)
+        echo -e "${GREEN}Starting interactive shell...${NC}"
+        docker run -it --rm \
+            -v "$(pwd):/app" \
+            --name $CONTAINER_NAME \
+            $IMAGE_NAME \
+            bash
+        ;;
+    test)
+        echo -e "${GREEN}Running tests...${NC}"
+        docker run --rm \
+            -v "$(pwd):/app" \
+            $IMAGE_NAME \
+            python -m pytest tests/ -v --tb=short
+        ;;
+    backtest)
+        echo -e "${GREEN}Running example backtest...${NC}"
+        docker run --rm \
+            -v "$(pwd):/app" \
+            $IMAGE_NAME \
+            python -c "
+from strategies.liquidity_sweep import LiquiditySweepStrategy
+from backtesting.runner import BacktestRunner
+import pandas as pd
+import numpy as np
+
+# Generate test data
+np.random.seed(42)
+dates = pd.date_range('2024-01-01', periods=500, freq='1h')
+trend = np.linspace(100, 150, 500)
+noise = np.random.randn(500) * 3
+close = trend + noise
+
+data = pd.DataFrame({
+    'open': close - np.random.rand(500),
+    'high': close + np.random.rand(500) * 3,
+    'low': close - np.random.rand(500) * 3,
+    'close': close,
+    'volume': np.random.randint(1000, 10000, 500)
+}, index=dates)
+
+# Run backtest
+strategy = LiquiditySweepStrategy()
+runner = BacktestRunner(initial_cash=10000)
+result = runner.run(data, strategy)
+
+print(f'''
+=== BACKTEST RESULTS ===
+Total Return: {result.total_return:.2%}
+Sharpe Ratio: {result.sharpe_ratio:.2f}
+Max Drawdown: {result.max_drawdown:.2%}
+Win Rate:     {result.win_rate:.2%}
+Total Trades: {result.total_trades}
+''')
+"
+        ;;
+    *)
+        echo "Usage: $0 [shell|test|backtest]"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
- Dockerfile: Python 3.11 + vectorbt + FractalTrader
- docker-compose.yml: dev + test services
- docker-start.sh: Quick-start script (shell/test/backtest)
- .dockerignore: Optimized build context

Compatible with Docker Desktop 4.15+ (Catalina)

Usage:
  ./docker-start.sh         # Interactive shell
  ./docker-start.sh test    # Run pytest
  ./docker-start.sh backtest # Example backtest